### PR TITLE
feat: added parameters to sendMessageVideo

### DIFF
--- a/nodes/TelePilot/TelePilot.node.ts
+++ b/nodes/TelePilot/TelePilot.node.ts
@@ -55,7 +55,14 @@ import {
 	variable_audio_binary_property_name,
 	variable_send_as_voice,
 	variable_json,
-	variable_url
+	variable_url,
+	variable_video_duration,
+	variable_video_width,
+	variable_video_height,
+	variable_video_supports_streaming,
+	variable_thumbnail_width,
+	variable_thumbnail_height,
+	variable_thumbnail_file_path,
 } from './common.descriptions'
 
 const debug = require('debug')('telepilot-node');
@@ -126,6 +133,13 @@ export class TelePilot implements INodeType {
 			variable_user_ids,
 			variable_chat_action,
 			variable_url,
+			variable_video_duration,
+			variable_video_width,
+			variable_video_height,
+			variable_video_supports_streaming,
+			variable_thumbnail_width,
+			variable_thumbnail_height,
+			variable_thumbnail_file_path,
 
 			//Variable Custom Request
 			variable_json,
@@ -581,6 +595,15 @@ export class TelePilot implements INodeType {
 					const chat_id = this.getNodeParameter('chat_id', 0) as string;
 					const videoFilePath = this.getNodeParameter('videoFilePath', 0) as string;
 					let videoCaption: string | null = this.getNodeParameter('fileCaption', 0) as string;
+					let videoDuration: number | null = this.getNodeParameter('videoDuration', 0) as number;
+					let videoWidth: number | null = this.getNodeParameter('videoWidth', 0) as number;
+					let videoHeight: number | null = this.getNodeParameter('videoHeight', 0) as number;
+					let videoSupportsStreaming: boolean | null = this.getNodeParameter('videoSupportsStreaming', 0) as boolean;
+
+					let thumbnailWidth: number | null = this.getNodeParameter('thumbnailWidth', 0) as number;
+					let thumbnailHeight: number | null = this.getNodeParameter('thumbnailHeight', 0) as number;
+					let thumbnailFilePath: string | null = this.getNodeParameter('thumbnailFilePath', 0) as string;
+
 					const reply_to_msg_id = this.getNodeParameter('reply_to_msg_id', 0) as string;
 					const message_thread_id = this.getNodeParameter('message_thread_id', 0) as number;
 
@@ -598,6 +621,19 @@ export class TelePilot implements INodeType {
 							video: {
 								_: 'inputFileLocal',
 								path: videoFilePath,
+							},
+							duration: videoDuration,
+							width: videoWidth,
+							height: videoHeight,
+							supports_streaming: videoSupportsStreaming,
+							thumbnail: {
+								_: 'inputThumbnail',
+								thumbnail: {
+									'_': 'inputFileLocal',
+									path: thumbnailFilePath
+								},
+								width: thumbnailWidth,
+								height: thumbnailHeight,
 							},
 							caption: {
 								_: 'formattedText',

--- a/nodes/TelePilot/common.descriptions.ts
+++ b/nodes/TelePilot/common.descriptions.ts
@@ -1000,3 +1000,100 @@ export const variable_url: INodeProperties = {
 	default: '',
 	placeholder: 'https://t.me/telepilotco/42'
 };
+
+export const variable_video_duration: INodeProperties = {
+	displayName: 'Duration Of The Video, In Seconds',
+	name: 'videoDuration',
+	type: 'number' as NodePropertyTypes,
+	displayOptions: {
+		show: {
+			operation: ['sendMessageVideo'],
+			resource: ['message'],
+		},
+	},
+	default: '',
+	placeholder: '30'
+};
+
+export const variable_video_width: INodeProperties = {
+	displayName: 'Video Width',
+	name: 'videoWidth',
+	type: 'number' as NodePropertyTypes,
+	displayOptions: {
+		show: {
+			operation: ['sendMessageVideo'],
+			resource: ['message'],
+		},
+	},
+	default: '',
+	placeholder: '320'
+};
+
+export const variable_video_height: INodeProperties = {
+	displayName: 'Video Height',
+	name: 'videoHeight',
+	type: 'number' as NodePropertyTypes,
+	displayOptions: {
+		show: {
+			operation: ['sendMessageVideo'],
+			resource: ['message'],
+		},
+	},
+	default: '',
+	placeholder: '320'
+};
+
+export const variable_video_supports_streaming: INodeProperties = {
+	displayName: 'On, If The Video Is Supposed To Be Streamed',
+	name: 'videoSupportsStreaming',
+	type: 'boolean' as NodePropertyTypes,
+	displayOptions: {
+		show: {
+			operation: ['sendMessageVideo'],
+			resource: ['message'],
+		},
+	},
+	default: 'true'
+};
+
+export const variable_thumbnail_width: INodeProperties = {
+	displayName: 'Thumbnail Width',
+	name: 'thumbnailWidth',
+	type: 'number' as NodePropertyTypes,
+	displayOptions: {
+		show: {
+			operation: ['sendMessageVideo'],
+			resource: ['message'],
+		},
+	},
+	default: '',
+	placeholder: '320'
+};
+
+export const variable_thumbnail_height: INodeProperties = {
+	displayName: 'Thumbnail Height',
+	name: 'thumbnailHeight',
+	type: 'number' as NodePropertyTypes,
+	displayOptions: {
+		show: {
+			operation: ['sendMessageVideo'],
+			resource: ['message'],
+		},
+	},
+	default: '',
+	placeholder: '320'
+};
+
+export const variable_thumbnail_file_path: INodeProperties = {
+	displayName: 'JPEG Thumnail Of The Video (Local File Path)',
+	name: 'thumbnailFilePath',
+	type: 'string' as NodePropertyTypes,
+	displayOptions: {
+		show: {
+			operation: ['sendMessageVideo'],
+			resource: ['message'],
+		},
+	},
+	default: '',
+	placeholder: '/home/telepilot/my-video-thumbnail.jpeg'
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telepilotco/n8n-nodes-telepilot",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Your personal Telegram CoPilot",
   "keywords": [
     "telepilot.co",
@@ -33,7 +33,7 @@
     "lint": "eslint nodes credentials",
     "lintfix": "eslint nodes credentials package.json --fix",
     "prepublishOnly": "npm run build && npm run lint -c .eslintrc.prepublish.js nodes credentials",
-    "start-n8n": "cd ~/projects/2025-dan/aoi_n8n && DEBUG=tdl,tdl:client,telepilot-cred,telepilot-node,telepilot-trigger,telepilot-cm N8N_LOG_LEVEL=debug npm run dev"
+    "start-n8n": "cd ~/projects/2025-telepilot/n8n && DEBUG=tdl,tdl:client,telepilot-cred,telepilot-node,telepilot-trigger,telepilot-cm N8N_LOG_LEVEL=debug npm run dev"
   },
   "n8n": {
     "n8nNodesApiVersion": 1,


### PR DESCRIPTION
Fixing https://github.com/telepilotco/n8n-nodes-telepilot/issues/22.

Added parameters to `sendMessageVideo` action:
 - Width: Video width
 - Height: Video height
 - Supports Streaming: whether or not video can be streamed (Boolean)
 - Thumbnail: Local path file to thumbnail (JPEG)
 - Thumbnail Width: Width of the Thumbnail (max. 320px)
 - Thumbnail Height: Height of the Thumbnail (max. 320px)