### PR TITLE
Removed redundant dependency

### DIFF
--- a/nodes/TelePilot/TelePilotNodeConnectionManager.ts
+++ b/nodes/TelePilot/TelePilotNodeConnectionManager.ts
@@ -1,8 +1,8 @@
 import 'reflect-metadata';
 import { Service } from 'typedi';
 import {IDataObject} from "n8n-workflow";
-const { Client } = require('@telepilotco/tdl');
-const tdl = require('@telepilotco/tdl');
+const { Client } = require('tdl');
+const tdl = require('tdl');
 // const childProcess = require('child_process');
 
 const debug = require('debug')('telepilot-cm')
@@ -13,7 +13,7 @@ var pjson = require('../../package.json');
 const nodeVersion = pjson.version;
 
 const binaryVersion = pjson.dependencies["@telepilotco/tdlib-binaries-prebuilt"].replace("^", "");
-const addonVersion = pjson.dependencies["@telepilotco/tdl"].replace("^", "");
+const addonVersion = pjson.dependencies["tdl"].replace("^", "");
 
 export enum TelepilotAuthState {
 	NO_CONNECTION = "NO_CONNECTION",

--- a/nodes/TelePilot/TelePilotTrigger.node.ts
+++ b/nodes/TelePilot/TelePilotTrigger.node.ts
@@ -11,7 +11,7 @@ const debug = require('debug')('telepilot-trigger')
 import {TelePilotNodeConnectionManager, TelepilotAuthState} from "./TelePilotNodeConnectionManager";
 import { TDLibUpdateEvents } from './tdlib/updateEvents';
 import { TDLibUpdate } from './tdlib/types'
-import {Client} from "@telepilotco/tdl";
+import {Client} from "tdl";
 
 
 export class TelePilotTrigger implements INodeType {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
-        "@telepilotco/tdl": "^7.4.1",
+        "tdl": "^7.4.1",
         "@telepilotco/tdlib-binaries-prebuilt": "^1.8.14",
         "debug": "^4.3.4",
         "typedi": "^0.10.0"
@@ -2757,8 +2757,8 @@
     },
     "node_modules/@telepilotco/tdl": {
       "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/@telepilotco/tdl/-/tdl-7.4.1.tgz",
-      "integrity": "sha512-fH6dLyIGKQ7lPkT0bSGg+isjz5vb886BMIVqALq07dyvvNkii+fYTQ/0yIBpfru+qzsWmfvQF7aoWhXSRFH3BA==",
+      "resolved": "https://registry.npmjs.org/tdl/-/tdl-7.4.1.tgz",
+      "integrity": "sha512-7EkVpgAndBAd+jMeRR+FI3v/Y0iy0bmcTDNACqp9Dtg+4AWdLb7fdjbMCEOuL2+ezjoslInXKx9SNWJ1vBT11A==",
       "hasInstallScript": true,
       "dependencies": {
         "debug": "^4.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2755,7 +2755,7 @@
       "dev": true,
       "peer": true
     },
-    "node_modules/@telepilotco/tdl": {
+    "node_modules/tdl": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/tdl/-/tdl-7.4.1.tgz",
       "integrity": "sha512-7EkVpgAndBAd+jMeRR+FI3v/Y0iy0bmcTDNACqp9Dtg+4AWdLb7fdjbMCEOuL2+ezjoslInXKx9SNWJ1vBT11A==",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "typescript": "~4.8.4"
   },
   "dependencies": {
-    "@telepilotco/tdl": "^7.4.1",
+    "tdl": "^7.4.1",
     "@telepilotco/tdlib-binaries-prebuilt": "^1.8.14",
     "debug": "^4.3.4",
     "typedi": "^0.10.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ importers:
 
   .:
     dependencies:
-      '@telepilotco/tdl':
+      'tdl':
         specifier: ^7.4.1
         version: 7.4.1
       '@telepilotco/tdlib-binaries-prebuilt':
@@ -542,8 +542,8 @@ packages:
   '@tediousjs/connection-string@0.3.0':
     resolution: {integrity: sha512-d/keJiNKfpHo+GmSB8QcsAwBx8h+V1UbdozA5TD+eSLXprNY53JAYub47J9evsSKWDdNG5uVj0FiMozLKuzowQ==}
 
-  '@telepilotco/tdl@7.4.1':
-    resolution: {integrity: sha512-fH6dLyIGKQ7lPkT0bSGg+isjz5vb886BMIVqALq07dyvvNkii+fYTQ/0yIBpfru+qzsWmfvQF7aoWhXSRFH3BA==}
+  'tdl@7.4.1':
+    resolution: {integrity: sha512-7EkVpgAndBAd+jMeRR+FI3v/Y0iy0bmcTDNACqp9Dtg+4AWdLb7fdjbMCEOuL2+ezjoslInXKx9SNWJ1vBT11A==}
 
   '@telepilotco/tdlib-binaries-prebuilt@1.8.14':
     resolution: {integrity: sha512-zDqfist7Y4q5mRBhimo1TKHWqtNt5gc6fk/Mw2iJL12LFDFnu00MdH47ZDUi61Dqd0JuJn3kr9zVRA9pl6LHUQ==}
@@ -5052,7 +5052,7 @@ snapshots:
 
   '@tediousjs/connection-string@0.3.0': {}
 
-  '@telepilotco/tdl@7.4.1':
+  'tdl@7.4.1':
     dependencies:
       debug: 4.3.4
       eventemitter3: 4.0.7


### PR DESCRIPTION
I thought I'd help by removing a redundant dependency by a more maintained variant.

Fixes #42
Fixes #43
Fixes #47  

Improves 📎privacy as well
An alternative is to respect N8N's `N8N_DIAGNOSTICS_ENABLED` environment variable

You can test it using the ´@lesleyxyz/n8n-nodes-telepilot´ community node